### PR TITLE
GitHub package source

### DIFF
--- a/Sources/ThirdPartyLibraries.NuGet.Test/NuGetApiTest.cs
+++ b/Sources/ThirdPartyLibraries.NuGet.Test/NuGetApiTest.cs
@@ -44,7 +44,7 @@ public class NuGetApiTest
         spec.ShouldNotBeNull();
         spec.Id.ShouldBe("StyleCop.Analyzers");
         spec.Version.ShouldBe("1.1.118");
-        spec.PackageHRef.ShouldBe("https://www.nuget.org/packages/StyleCop.Analyzers/1.1.118");
+        spec.PackageHRef.ShouldBeNull();
         spec.Description.ShouldBe("An implementation of StyleCop's rules using Roslyn analyzers and code fixes");
         spec.Authors.ShouldBe("Sam Harwell et. al.");
         spec.Copyright.ShouldBe("Copyright 2015 Tunnel Vision Laboratories, LLC");
@@ -71,7 +71,7 @@ public class NuGetApiTest
         spec.ShouldNotBeNull();
         spec.Id.ShouldBe("Newtonsoft.Json");
         spec.Version.ShouldBe("12.0.2");
-        spec.PackageHRef.ShouldBe("https://www.nuget.org/packages/Newtonsoft.Json/12.0.2");
+        spec.PackageHRef.ShouldBeNull();
         spec.Description.ShouldBe("Json.NET is a popular high-performance JSON framework for .NET");
         spec.Authors.ShouldBe("James Newton-King");
         spec.Copyright.ShouldBe("Copyright © James Newton-King 2008");
@@ -123,7 +123,7 @@ public class NuGetApiTest
         spec.ShouldNotBeNull();
         spec.Id.ShouldBe("Common.Logging");
         spec.Version.ShouldBe("2.0.0");
-        spec.PackageHRef.ShouldBe("https://www.nuget.org/packages/Common.Logging/2.0.0");
+        spec.PackageHRef.ShouldBeNull();
         spec.Description.ShouldBe("Common.Logging library introduces a simple abstraction to allow you to select a specific logging implementation at runtime.");
         spec.Authors.ShouldBe("Aleksandar Seovic, Mark Pollack, Erich Eichinger");
         spec.Copyright.ShouldBeNull();

--- a/Sources/ThirdPartyLibraries.NuGet.Test/NuGetMetadataParserTest.cs
+++ b/Sources/ThirdPartyLibraries.NuGet.Test/NuGetMetadataParserTest.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+using Shouldly;
+
+namespace ThirdPartyLibraries.NuGet;
+
+[TestFixture]
+public class NuGetMetadataParserTest
+{
+    [Test]
+    public void ParseVersion2()
+    {
+        using var stream = TempFile.OpenResource(GetType(), "NuGetMetadataParserTest.metadata2.json");
+
+        var actual = NuGetMetadataParser.Parse(stream);
+
+        actual.Version.ShouldBe(2);
+        actual.Source.ShouldBe("https://nuget.pkg.github.com/organization/index.json");
+    }
+
+    [Test]
+    public void ParseVersion1()
+    {
+        using var stream = TempFile.OpenResource(GetType(), "NuGetMetadataParserTest.metadata1.json");
+
+        var actual = NuGetMetadataParser.Parse(stream);
+
+        actual.Version.ShouldBe(1);
+        actual.Source.ShouldBeNull();
+    }
+}

--- a/Sources/ThirdPartyLibraries.NuGet.Test/NuGetMetadataParserTest.metadata1.json
+++ b/Sources/ThirdPartyLibraries.NuGet.Test/NuGetMetadataParserTest.metadata1.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "contentHash": "base64 string"
+}

--- a/Sources/ThirdPartyLibraries.NuGet.Test/NuGetMetadataParserTest.metadata2.json
+++ b/Sources/ThirdPartyLibraries.NuGet.Test/NuGetMetadataParserTest.metadata2.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "contentHash": "base64 string",
+  "source": "https://nuget.pkg.github.com/organization/index.json"
+}

--- a/Sources/ThirdPartyLibraries.NuGet/INuGetApi.cs
+++ b/Sources/ThirdPartyLibraries.NuGet/INuGetApi.cs
@@ -17,4 +17,6 @@ public interface INuGetApi
     Task<byte[]> LoadFileContentAsync(byte[] packageContent, string fileName, CancellationToken token);
 
     string[] FindFiles(byte[] packageContent, string searchPattern);
+
+    string ResolvePackageSource(NuGetPackageId package);
 }

--- a/Sources/ThirdPartyLibraries.NuGet/NuGetApi.cs
+++ b/Sources/ThirdPartyLibraries.NuGet/NuGetApi.cs
@@ -147,6 +147,23 @@ internal sealed class NuGetApi : INuGetApi
         return result.ToArray();
     }
 
+    public string ResolvePackageSource(NuGetPackageId package)
+    {
+        var fileName = Path.Combine(GetLocalCachePath(package), ".nupkg.metadata");
+        if (!File.Exists(fileName))
+        {
+            return null;
+        }
+
+        string result;
+        using (var stream = File.OpenRead(fileName))
+        {
+            result = NuGetMetadataParser.Parse(stream).Source;
+        }
+
+        return string.IsNullOrWhiteSpace(result) ? null : result;
+    }
+
     internal static string ExtractLicenseCode(string licenseUrl)
     {
         var expression = new UriBuilder(licenseUrl).Path.Trim();

--- a/Sources/ThirdPartyLibraries.NuGet/NuGetMetadata.cs
+++ b/Sources/ThirdPartyLibraries.NuGet/NuGetMetadata.cs
@@ -1,0 +1,14 @@
+﻿namespace ThirdPartyLibraries.NuGet;
+
+internal readonly record struct NuGetMetadata
+{
+    public NuGetMetadata(int version, string source)
+    {
+        Version = version;
+        Source = source;
+    }
+
+    public int Version { get; }
+
+    public string Source { get; }
+}

--- a/Sources/ThirdPartyLibraries.NuGet/NuGetMetadataParser.cs
+++ b/Sources/ThirdPartyLibraries.NuGet/NuGetMetadataParser.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+using Newtonsoft.Json.Linq;
+using ThirdPartyLibraries.Shared;
+
+namespace ThirdPartyLibraries.NuGet;
+
+internal static class NuGetMetadataParser
+{
+    public static NuGetMetadata Parse(Stream stream)
+    {
+        var content = stream.JsonDeserialize<JObject>();
+
+        return new NuGetMetadata(content.Value<int>("version"), content.Value<string>("source"));
+    }
+}

--- a/Sources/ThirdPartyLibraries.NuGet/NuGetSpecParser.cs
+++ b/Sources/ThirdPartyLibraries.NuGet/NuGetSpecParser.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web;
 using System.Xml;
 using System.Xml.XPath;
 using NuGet.Versioning;
@@ -28,7 +27,6 @@ internal static class NuGetSpecParser
         ns.AddNamespace("n", namespaceUri);
 
         var spec = ParseSpec(FindMetaData(doc), ns);
-        spec.PackageHRef = "https://" + KnownHosts.NuGetOrg + "/packages/" + HttpUtility.UrlEncode(spec.Id) + "/" + HttpUtility.UrlEncode(spec.Version);
         spec.Version = new SemanticVersion(spec.Version).Version;
 
         return spec;

--- a/Sources/ThirdPartyLibraries.Repository/Template/LibraryIndexJson.cs
+++ b/Sources/ThirdPartyLibraries.Repository/Template/LibraryIndexJson.cs
@@ -1,9 +1,13 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace ThirdPartyLibraries.Repository.Template;
 
 public sealed class LibraryIndexJson
 {
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string Source { get; set; }
+
     public LicenseConclusion License { get; } = new LicenseConclusion();
 
     public IList<Application> UsedBy { get; } = new List<Application>();

--- a/Sources/ThirdPartyLibraries.Shared/KnownHosts.cs
+++ b/Sources/ThirdPartyLibraries.Shared/KnownHosts.cs
@@ -16,6 +16,8 @@ public static class KnownHosts
 
     public const string GitHubApi = "api.github.com";
 
+    public const string GitHubNuGet = "nuget.pkg.github.com";
+
     public const string ApacheOrg = "www.apache.org";
 
     public const string OpenSourceOrg = "opensource.org";

--- a/Sources/ThirdPartyLibraries.Suite.Test/Internal/GitHubAdapters/GitHubNuGetPackageUrlResolverTest.cs
+++ b/Sources/ThirdPartyLibraries.Suite.Test/Internal/GitHubAdapters/GitHubNuGetPackageUrlResolverTest.cs
@@ -1,0 +1,49 @@
+﻿using Moq;
+using NUnit.Framework;
+using Shouldly;
+using ThirdPartyLibraries.GitHub;
+
+namespace ThirdPartyLibraries.Suite.Internal.GitHubAdapters;
+
+[TestFixture]
+public class GitHubNuGetPackageUrlResolverTest
+{
+    private const string Source = "https://nuget.pkg.github.com/org-name/index.json";
+
+    private Mock<IGitHubApi> _gitHubApi;
+    private GitHubNuGetPackageUrlResolver _sut;
+
+    [SetUp]
+    public void BeforeEachTest()
+    {
+        _gitHubApi = new Mock<IGitHubApi>(MockBehavior.Strict);
+        _sut = new GitHubNuGetPackageUrlResolver(_gitHubApi.Object);
+    }
+
+    [Test]
+    public void GetUserUrlBoundToRepo()
+    {
+        var repositoryUrl = "https://github.com/org-name/repo-name";
+        var owner = "org-name";
+        var repoName = "repo-name";
+
+        _gitHubApi
+            .Setup(g => g.TryExtractRepositoryName(repositoryUrl, out owner, out repoName))
+            .Returns(true);
+
+        var actual = _sut.GetUserUrl("package-name", "package-version", Source, repositoryUrl);
+
+        // ignore version
+        //   github uses magic-id in the path insteadof version
+        //   e.g. https://github.com/org-name/repo-name/pkgs/nuget/package-name/12345
+        actual.HRef.ShouldBe("https://github.com/org-name/repo-name/pkgs/nuget/package-name");
+    }
+
+    [Test]
+    public void GetUserUrlBoundToPackage()
+    {
+        var actual = _sut.GetUserUrl("package.name", "package-version", Source, null);
+
+        actual.HRef.ShouldBe("https://github.com/org-name/package/pkgs/nuget/package.name");
+    }
+}

--- a/Sources/ThirdPartyLibraries.Suite/AppModule.cs
+++ b/Sources/ThirdPartyLibraries.Suite/AppModule.cs
@@ -32,6 +32,7 @@ public static class AppModule
         services.AddKeyedTransient<IPackageResolver, NuGetPackageResolver>(PackageSources.NuGet);
         services.AddKeyedTransient<ILicenseSourceByUrl, NuGetLicenseSource>(KnownHosts.NuGetLicense);
         services.AddKeyedTransient<IPackageRepositoryAdapter, NuGetPackageRepositoryAdapter>(PackageSources.NuGet);
+        services.AddKeyedTransient<INuGetPackageUrlResolver, DefaultNuGetPackageUrlResolver>(KnownHosts.NuGetApi);
 
         // npm
         services.AddSingleton(ResolveNpmConfiguration);
@@ -45,6 +46,7 @@ public static class AppModule
         services.AddKeyedTransient<ILicenseSourceByUrl, GitHubLicenseSource>(KnownHosts.GitHubRaw);
         services.AddKeyedTransient<ILicenseSourceByUrl, GitHubLicenseSource>(KnownHosts.GitHubRawUserContent);
         services.AddKeyedTransient<ILicenseSourceByUrl, GitHubLicenseSource>(KnownHosts.GitHubApi);
+        services.AddKeyedTransient<INuGetPackageUrlResolver, GitHubNuGetPackageUrlResolver>(KnownHosts.GitHubNuGet);
 
         // custom
         services.AddKeyedTransient<IPackageRepositoryAdapter, CustomPackageRepositoryAdapter>(PackageSources.Custom);

--- a/Sources/ThirdPartyLibraries.Suite/Commands/RefreshCommand.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Commands/RefreshCommand.cs
@@ -34,7 +34,7 @@ public sealed class RefreshCommand : ICommand
 
             var packageContext = new RootReadMePackageContext
             {
-                Source = metadata.SourceCode,
+                Source = metadata.HRefText,
                 Name = metadata.Name,
                 Version = metadata.Version,
                 License = metadata.LicenseCode,

--- a/Sources/ThirdPartyLibraries.Suite/Internal/CustomAdapters/CustomPackageRepositoryAdapter.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/CustomAdapters/CustomPackageRepositoryAdapter.cs
@@ -25,6 +25,7 @@ internal sealed class CustomPackageRepositoryAdapter : IPackageRepositoryAdapter
             Author = index.Author,
             Copyright = index.Copyright,
             HRef = index.HRef,
+            HRefText = PackageSources.Custom,
             UsedBy = index.UsedBy.Select(i => new PackageApplication(i.Name, i.InternalOnly)).ToArray(),
             ApprovalStatus = PackageApprovalStatus.Approved
         };

--- a/Sources/ThirdPartyLibraries.Suite/Internal/GenericAdapters/PackageRepositoryAdapterBase.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/GenericAdapters/PackageRepositoryAdapterBase.cs
@@ -20,6 +20,7 @@ internal abstract class PackageRepositoryAdapterBase : IPackageRepositoryAdapter
         {
             SourceCode = id.SourceCode,
             LicenseCode = index.License.Code,
+            HRef = index.Source,
             UsedBy = index.UsedBy.Select(i => new PackageApplication(i.Name, i.InternalOnly)).ToArray()
         };
 

--- a/Sources/ThirdPartyLibraries.Suite/Internal/GitHubAdapters/GitHubNuGetPackageUrlResolver.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/GitHubAdapters/GitHubNuGetPackageUrlResolver.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using ThirdPartyLibraries.GitHub;
+using ThirdPartyLibraries.Shared;
+
+namespace ThirdPartyLibraries.Suite.Internal.GitHubAdapters;
+
+internal sealed class GitHubNuGetPackageUrlResolver : INuGetPackageUrlResolver
+{
+    private readonly IGitHubApi _gitHubApi;
+
+    public GitHubNuGetPackageUrlResolver(IGitHubApi gitHubApi)
+    {
+        _gitHubApi = gitHubApi;
+    }
+
+    public (string Text, string HRef) GetUserUrl(string packageName, string packageVersion, string source, string repositoryUrl)
+    {
+        if (!TryExtractRepositoryName(repositoryUrl, out var owner, out var repository))
+        {
+            owner = GetOwner(new Uri(source, UriKind.Absolute).AbsolutePath);
+            repository = GetRepository(packageName);
+        }
+
+        var href = "https://" + KnownHosts.GitHub + "/" + owner + "/" + repository + "/pkgs/nuget/" + Uri.EscapeDataString(packageName);
+        return (KnownHosts.GitHub, href);
+    }
+
+    private static string GetOwner(ReadOnlySpan<char> sourcePath)
+    {
+        if (sourcePath[0] == '/')
+        {
+            sourcePath = sourcePath.Slice(1);
+        }
+
+        var index = sourcePath.IndexOf('/');
+        return sourcePath.Slice(0, index).ToString();
+    }
+
+    private static string GetRepository(string packageName)
+    {
+        var index = packageName.IndexOf('.');
+        if (index > 0)
+        {
+            return packageName.Substring(0, index);
+        }
+
+        return packageName;
+    }
+
+    private bool TryExtractRepositoryName(string url, out string owner, out string name)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            owner = null;
+            name = null;
+            return false;
+        }
+
+        return _gitHubApi.TryExtractRepositoryName(url, out owner, out name);
+    }
+}

--- a/Sources/ThirdPartyLibraries.Suite/Internal/INuGetPackageUrlResolver.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/INuGetPackageUrlResolver.cs
@@ -1,0 +1,6 @@
+﻿namespace ThirdPartyLibraries.Suite.Internal;
+
+internal interface INuGetPackageUrlResolver
+{
+    (string Text, string HRef) GetUserUrl(string packageName, string packageVersion, string source, string repositoryUrl);
+}

--- a/Sources/ThirdPartyLibraries.Suite/Internal/NpmAdapters/NpmPackageRepositoryAdapter.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/NpmAdapters/NpmPackageRepositoryAdapter.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using ThirdPartyLibraries.Npm;
 using ThirdPartyLibraries.Repository;
+using ThirdPartyLibraries.Shared;
 using ThirdPartyLibraries.Suite.Internal.GenericAdapters;
 
 namespace ThirdPartyLibraries.Suite.Internal.NpmAdapters;
@@ -24,6 +25,7 @@ internal sealed class NpmPackageRepositoryAdapter : PackageRepositoryAdapterBase
         package.Version = json.Version;
         package.Description = json.Description;
         package.HRef = json.PackageHRef;
+        package.HRefText = PackageSources.Npm;
         package.Author = json.Authors;
     }
 

--- a/Sources/ThirdPartyLibraries.Suite/Internal/NuGetAdapters/DefaultNuGetPackageUrlResolver.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/NuGetAdapters/DefaultNuGetPackageUrlResolver.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using ThirdPartyLibraries.Shared;
+
+namespace ThirdPartyLibraries.Suite.Internal.NuGetAdapters;
+
+internal sealed class DefaultNuGetPackageUrlResolver : INuGetPackageUrlResolver
+{
+    public (string Text, string HRef) GetUserUrl(string packageName, string packageVersion, string source, string repositoryUrl)
+    {
+        var href = "https://" + KnownHosts.NuGetOrg + "/packages/" + Uri.EscapeDataString(packageName) + "/" + Uri.EscapeDataString(packageVersion);
+        return (PackageSources.NuGet, href);
+    }
+}

--- a/Sources/ThirdPartyLibraries.Suite/Internal/NuGetAdapters/NuGetPackageRepositoryAdapter.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/NuGetAdapters/NuGetPackageRepositoryAdapter.cs
@@ -1,19 +1,25 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using ThirdPartyLibraries.NuGet;
 using ThirdPartyLibraries.Repository;
+using ThirdPartyLibraries.Shared;
 using ThirdPartyLibraries.Suite.Internal.GenericAdapters;
 
 namespace ThirdPartyLibraries.Suite.Internal.NuGetAdapters;
 
 internal sealed class NuGetPackageRepositoryAdapter : PackageRepositoryAdapterBase
 {
-    public NuGetPackageRepositoryAdapter(INuGetApi api)
+    public NuGetPackageRepositoryAdapter(IServiceProvider serviceProvider)
     {
-        Api = api;
+        Api = serviceProvider.GetRequiredService<INuGetApi>();
+        ServiceProvider = serviceProvider;
     }
 
     public INuGetApi Api { get; }
+
+    public IServiceProvider ServiceProvider { get; }
 
     protected override async Task AppendSpecAttributesAsync(LibraryId id, Package package, CancellationToken token)
     {
@@ -21,7 +27,7 @@ internal sealed class NuGetPackageRepositoryAdapter : PackageRepositoryAdapterBa
         package.Name = spec.Id;
         package.Version = spec.Version;
         package.Description = spec.Description;
-        package.HRef = spec.PackageHRef;
+        (package.HRefText, package.HRef) = GetUrlResolver(package.HRef).GetUserUrl(spec.Id, spec.Version, package.HRef, spec.Repository?.Url);
         package.Author = spec.Authors;
         package.Copyright = spec.Copyright;
     }
@@ -32,5 +38,21 @@ internal sealed class NuGetPackageRepositoryAdapter : PackageRepositoryAdapterBa
         {
             return Api.ParseSpec(specContent);
         }
+    }
+
+    private INuGetPackageUrlResolver GetUrlResolver(string source)
+    {
+        INuGetPackageUrlResolver result = null;
+        if (Uri.TryCreate(source, UriKind.Absolute, out var url))
+        {
+            result = ServiceProvider.GetKeyedService<INuGetPackageUrlResolver>(url.Host);
+        }
+
+        if (result == null)
+        {
+            result = ServiceProvider.GetRequiredKeyedService<INuGetPackageUrlResolver>(KnownHosts.NuGetApi);
+        }
+
+        return result;
     }
 }

--- a/Sources/ThirdPartyLibraries.Suite/Internal/NuGetAdapters/NuGetPackageResolver.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Internal/NuGetAdapters/NuGetPackageResolver.cs
@@ -46,6 +46,8 @@ internal sealed class NuGetPackageResolver : PackageResolverBase
         {
             index.Licenses.Add(await ResolveUrlLicenseAsync(id, spec.ProjectUrl, PackageLicense.SubjectProject, token).ConfigureAwait(false));
         }
+
+        index.Source = Api.ResolvePackageSource(new NuGetPackageId(id.Name, id.Version));
     }
 
     protected override Task<byte[]> DownloadPackageContentAsync(LibraryId id, CancellationToken token)

--- a/Sources/ThirdPartyLibraries.Suite/Package.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Package.cs
@@ -22,6 +22,9 @@ public sealed class Package
 
     public PackageApprovalStatus ApprovalStatus { get; set; }
 
+    // nuget.org, github.com
+    public string HRefText { get; set; }
+
     // https://www.nuget.org/packages/Newtonsoft.Json/12.0.2
     public string HRef { get; set; }
 


### PR DESCRIPTION
- resolve download nuget package source
- customize nuget package url in readmes 

**For example after "dotnet restore"**

Package Microsoft.Extensions.Options version 7.0.1 was restored from `https://api.nuget.org/v3/index.json`. In readmes, it has a source `nuget.org` and url `https://www.nuget.org/packages/Microsoft.Extensions.Options/7.0.1` - like in previous versions.

Package SomePackage version 1.0 was restored from `https://nuget.pkg.github.com/MyOrg/index.json`. In readmes, it has a source `github.com` and url `https://github.com/MyOrg/MyRepo/pkgs/nuget/SomePackage` - new behavior.

Related to #55.