### PR TITLE
feature/log http request

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ The configuration file [appsettings.json](ThirdPartyLibraries/configuration/apps
     ]
   },
   "skipCertificateCheck": {
-    "byHost": [ "localhost" ]
+    "byHost": [ "localhost" ],
+    "logRequest": true
   }
 }
 ```
@@ -267,6 +268,7 @@ setup well-know licenses
 ### skipCertificateCheck
 
 - `byHost`: regex expressions array. Ignore server certificate validation for specific hosts
+- `logRequest`: *true* or *false* (default) flag to log any HTTP request
 
 [Back to ToC](#table-of-contents)
 

--- a/Sources/ThirdPartyLibraries.Repository/Template/appsettings.json
+++ b/Sources/ThirdPartyLibraries.Repository/Template/appsettings.json
@@ -67,6 +67,7 @@
     ]
   },
   "skipCertificateCheck": {
-    "byHost": [ "localhost" ]
+    "byHost": [ "localhost" ],
+    "logRequest": false
   }
 }

--- a/Sources/ThirdPartyLibraries.Suite/Configuration/SkipCertificateCheckConfiguration.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Configuration/SkipCertificateCheckConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 
 namespace ThirdPartyLibraries.Suite.Configuration;
 
@@ -7,18 +6,7 @@ public sealed class SkipCertificateCheckConfiguration
 {
     public const string SectionName = "skipCertificateCheck";
 
-    public SkipCertificateCheckConfiguration()
-    {
-        ForceLogRequest();
-    }
-
     public string[] ByHost { get; set; } = Array.Empty<string>();
 
     public bool LogRequest { get; set; }
-
-    [Conditional("DEBUG")]
-    private void ForceLogRequest()
-    {
-        LogRequest = true;
-    }
 }

--- a/Sources/ThirdPartyLibraries.Suite/Shared/Internal/HttpClientFactory.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Shared/Internal/HttpClientFactory.cs
@@ -44,12 +44,20 @@ internal sealed class HttpClientFactory
         }
 
         var host = request.RequestUri?.Host;
-        if (string.IsNullOrEmpty(host))
+        if (string.IsNullOrEmpty(host) || !new IgnoreFilter(_configuration.ByHost).Filter(host))
         {
             return false;
         }
 
-        return new IgnoreFilter(_configuration.ByHost).Filter(host);
+        if (_configuration.LogRequest)
+        {
+            using (_logger.Indent())
+            {
+                _logger.Warn($"ignore invalid server certificate on {request.RequestUri}");
+            }
+        }
+
+        return true;
     }
 
     private HttpClientHandler CreateHandler()

--- a/ThirdPartyLibraries/configuration/appsettings.json
+++ b/ThirdPartyLibraries/configuration/appsettings.json
@@ -59,6 +59,7 @@
     ]
   },
   "skipCertificateCheck": {
-    "byHost": [ "localhost" ]
+    "byHost": [ "localhost" ],
+    "logRequest": true
   }
 }


### PR DESCRIPTION
New configuration flag `skipCertificateCheck.logRequest`, by default false.

It is enabled:
- write into the log request URL on any HTTP request
- write a warning if an invalid server certificate is suppressed by configuration