### PR TITLE
UpdateCommand: try resolve license code by the license file conent

### DIFF
--- a/Sources/ThirdPartyLibraries.Repository.Test/FileStorageTest.cs
+++ b/Sources/ThirdPartyLibraries.Repository.Test/FileStorageTest.cs
@@ -105,6 +105,24 @@ public class FileStorageTest
     }
 
     [Test]
+    [TestCase("nuget.org", "Newtonsoft.Json", "12.0.2")]
+    [TestCase("npmjs.com", "@types/angular", "1.6.51")]
+    [TestCase("npmjs.com", "angular-unknown", null)]
+    public async Task GetAllLibraryVersionsAsync(string sourceCode, string name, string? expected)
+    {
+        var actual = await _sut.GetAllLibraryVersionsAsync(sourceCode, name, default).ConfigureAwait(false);
+        
+        if (expected == null)
+        {
+            actual.ShouldBeEmpty();
+        }
+        else
+        {
+            actual.ShouldBe(new[] { new LibraryId(sourceCode, name, expected) });
+        }
+    }
+
+    [Test]
     public async Task GetAllLicenseCodes()
     {
         var actual = await _sut.GetAllLicenseCodesAsync(default).ConfigureAwait(false);

--- a/Sources/ThirdPartyLibraries.Repository/IStorage.cs
+++ b/Sources/ThirdPartyLibraries.Repository/IStorage.cs
@@ -14,6 +14,8 @@ public interface IStorage
 
     Task<List<string>> GetAllLicenseCodesAsync(CancellationToken token);
 
+    Task<List<LibraryId>> GetAllLibraryVersionsAsync(string sourceCode, string name, CancellationToken token);
+
     string GetPackageLocalHRef(LibraryId id, LibraryId? relativeTo = null);
 
     string GetLicenseLocalHRef(string licenseCode, LibraryId? relativeTo = null);

--- a/Sources/ThirdPartyLibraries.Suite/Update/Internal/ILicenseByContentResolver.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Update/Internal/ILicenseByContentResolver.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using ThirdPartyLibraries.Domain;
+
+namespace ThirdPartyLibraries.Suite.Update.Internal;
+
+internal interface ILicenseByContentResolver
+{
+    Task<IdenticalLicenseFile?> TryResolveAsync(LibraryId library, CancellationToken token);
+}

--- a/Sources/ThirdPartyLibraries.Suite/Update/Internal/IdenticalLicenseFile.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Update/Internal/IdenticalLicenseFile.cs
@@ -1,0 +1,14 @@
+﻿namespace ThirdPartyLibraries.Suite.Update.Internal;
+
+internal sealed class IdenticalLicenseFile
+{
+    public IdenticalLicenseFile(string licenseCode, string description)
+    {
+        LicenseCode = licenseCode;
+        Description = description;
+    }
+
+    public string LicenseCode { get; }
+    
+    public string Description { get; }
+}

--- a/Sources/ThirdPartyLibraries.Suite/Update/Internal/LicenseByContentResolver.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Update/Internal/LicenseByContentResolver.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ThirdPartyLibraries.Domain;
+using ThirdPartyLibraries.Repository;
+using ThirdPartyLibraries.Repository.Template;
+using ThirdPartyLibraries.Suite.Shared;
+
+namespace ThirdPartyLibraries.Suite.Update.Internal;
+
+internal sealed class LicenseByContentResolver : ILicenseByContentResolver
+{
+    private readonly IStorage _storage;
+    private readonly ILicenseHashBuilder _hashBuilder;
+    private readonly Dictionary<string, StorageLicenseFile?> _storageLicenseByCode;
+
+    public LicenseByContentResolver(IStorage storage, ILicenseHashBuilder hashBuilder)
+    {
+        _storage = storage;
+        _hashBuilder = hashBuilder;
+        _storageLicenseByCode = new Dictionary<string, StorageLicenseFile?>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task<IdenticalLicenseFile?> TryResolveAsync(LibraryId library, CancellationToken token)
+    {
+        var (_, hash) = await _hashBuilder.GetHashAsync(library, PackageSpecLicense.SubjectPackage, token).ConfigureAwait(false);
+
+        // no license file
+        if (!hash.HasValue)
+        {
+            return null;
+        }
+
+        var result = await LookAtOtherVersionsAsync(library, hash.Value, token).ConfigureAwait(false);
+        if (result == null)
+        {
+            result = await LookAtLicensesAsync(hash.Value, token).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    private async Task<IdenticalLicenseFile?> LookAtOtherVersionsAsync(LibraryId library, ArrayHash hash, CancellationToken token)
+    {
+        var versions = await _storage.GetAllLibraryVersionsAsync(library.SourceCode, library.Name, token).ConfigureAwait(false);
+        for (var i = 0; i < versions.Count; i++)
+        {
+            var other = versions[i];
+            if (other.Version.Equals(library.Version, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var (_, otherHash) = await _hashBuilder.GetHashAsync(other, PackageSpecLicense.SubjectPackage, token).ConfigureAwait(false);
+            if (!otherHash.HasValue || !otherHash.Value.Equals(hash))
+            {
+                continue;
+            }
+
+            var otherIndex = await _storage.ReadLibraryIndexJsonAsync<LibraryIndexJson>(other, token).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(otherIndex?.License.Code))
+            {
+                continue;
+            }
+
+            return new IdenticalLicenseFile(otherIndex.License.Code, $"The license file is identical to the file from version {other.Version}.");
+        }
+
+        return null;
+    }
+
+    private async Task<IdenticalLicenseFile?> LookAtLicensesAsync(ArrayHash hash, CancellationToken token)
+    {
+        var codes = await _storage.GetAllLicenseCodesAsync(token).ConfigureAwait(false);
+
+        for (var i = 0; i < codes.Count; i++)
+        {
+            var file = await GetStorageLicenseAsync(codes[i], token).ConfigureAwait(false);
+            if (file != null && file.Hash.Equals(hash))
+            {
+                return file.File;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task<StorageLicenseFile?> GetStorageLicenseAsync(string code, CancellationToken token)
+    {
+        if (_storageLicenseByCode.TryGetValue(code, out var result))
+        {
+            return result;
+        }
+
+        var index = await _storage.ReadLicenseIndexJsonAsync(code, token).ConfigureAwait(false);
+        if (index == null)
+        {
+            return null;
+        }
+
+        ArrayHash? hash = null;
+        if (!string.IsNullOrEmpty(index.FileName))
+        {
+            hash = await _hashBuilder.GetHashAsync(index.Code, index.FileName, token).ConfigureAwait(false);
+        }
+
+        result = null;
+        if (hash.HasValue)
+        {
+            result = new StorageLicenseFile(
+                new IdenticalLicenseFile(index.Code, $"The license file is identical to the {index.Code} license file."),
+                hash.Value);
+        }
+
+        _storageLicenseByCode.Add(code, result);
+        return result;
+    }
+
+    private sealed class StorageLicenseFile
+    {
+        public StorageLicenseFile(IdenticalLicenseFile file, ArrayHash hash)
+        {
+            File = file;
+            Hash = hash;
+        }
+
+        public IdenticalLicenseFile File { get; }
+        
+        public ArrayHash Hash { get; }
+    }
+}

--- a/Sources/ThirdPartyLibraries.Suite/Update/UpdateCommandModule.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Update/UpdateCommandModule.cs
@@ -9,6 +9,7 @@ internal static class UpdateCommandModule
     {
         services.AddSingleton<ILicenseByCodeResolver, LicenseByCodeResolver>();
         services.AddSingleton<ILicenseByUrlResolver, LicenseByUrlResolver>();
+        services.AddSingleton<ILicenseByContentResolver, LicenseByContentResolver>();
         services.AddSingleton<IPackageContentUpdater, PackageContentUpdater>();
         services.AddSingleton<IPackageLicenseUpdater, PackageLicenseUpdater>();
         services.AddSingleton<IStorageLicenseUpdater, StorageLicenseUpdater>();


### PR DESCRIPTION
If a license code is not defined in a package, but the package contains a license file:

1. Check other versions of this package in the repository
If the other version contains an identical license file, copy the license code with the description `The license file is identical to the file from version {Version}`

2. Check repository license files
If the license is defined with an identical license file, copy the license code with the description `The license file is identical to the {Code} license file.`

**As an example nuget package `Microsoft.NET.Test.Sdk`**

Spec contains only LICENSE_NET.txt:
```xml
<package>
  <metadata>
    <id>Microsoft.NET.Test.Sdk</id>
    <version>17.6.3</version>
    <license type="file">LICENSE_NET.txt</license>
  </metadata>
</package>
```

When the first time the package appears in the repository, a license `ms-net-library` cannot be resolved automatically. The license code should be updated manually.

index.json
```json
{
  "License": {
    "Code": "ms-net-library",
  },
  "Licenses": [
    {
      "Subject": "package",
      "Code": null,
      "HRef": "LICENSE_NET.txt"
    }
  ]
}
```
Update Microsoft.NET.Test.Sdk from version 17.6.3 to 17.7.2. Version 17.7.2 as well contains only LICENSE_NET.txt:
```xml
<package>
  <metadata>
    <id>Microsoft.NET.Test.Sdk</id>
    <version>17.7.2</version>
    <license type="file">LICENSE_NET.txt</license>
  </metadata>
</package>
```

The content of LICENSE_NET.txt in 17.7.2 is identical to 17.6.3, so the tool automatically assigns `ms-net-library` license code for version 17.7.2:
```json
{
  "License": {
    "Code": "ms-net-library",
  },
  "Licenses": [
    {
      "Subject": "package",
      "Code": "ms-net-library",
      "HRef": "LICENSE_NET.txt",
      "Description": "The license file is identical to the file from version 17.6.3"
    }
  ]
}
```
