### PR TITLE
UpdateCommand: try resolve license code by the license file conent from other subjects

### DIFF
--- a/Sources/ThirdPartyLibraries.Suite/Update/Internal/ILicenseByContentResolver.cs
+++ b/Sources/ThirdPartyLibraries.Suite/Update/Internal/ILicenseByContentResolver.cs
@@ -1,10 +1,12 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ThirdPartyLibraries.Domain;
+using ThirdPartyLibraries.Repository.Template;
 
 namespace ThirdPartyLibraries.Suite.Update.Internal;
 
 internal interface ILicenseByContentResolver
 {
-    Task<IdenticalLicenseFile?> TryResolveAsync(LibraryId library, CancellationToken token);
+    Task<IdenticalLicenseFile?> TryResolveAsync(LibraryId library, List<LibraryLicense> libraryLicenses, CancellationToken token);
 }


### PR DESCRIPTION
If a license code is not defined in a package, but the package contains a license file, check other subjects of this package.

If the other subject contains an identical license file, copy the license code with the description `The license file is identical to the {Subject} license file.`

**As an example nuget package `CompareNETObjects`**

Spec contains only LICENSE_NET.txt:
```xml
<package>
  <metadata>
    <id>CompareNETObjects</id>
    <version>4.79.0</version>
    <license type="file">License.txt</license>
    <projectUrl>https://github.com/GregFinzer/Compare-Net-Objects</projectUrl>
  </metadata>
</package>
```

The project URL is GitHub repository `GregFinzer/Compare-Net-Objects`

- with [MS-PL license](https://api.github.com/repos/GregFinzer/Compare-Net-Objects/license)
- the license content on GitHub is identical to the License.txt in the package

```json
{
  "License": {
    "Code": "MS-PL",
  },
  "Licenses": [
    {
      "Subject": "package",
      "Code": "MS-PL",
      "HRef": "License.txt",
      "Description": "The license file is identical to the project license file."
    },
    {
      "Subject": "project",
      "Code": "MS-PL",
      "HRef": "https://github.com/GregFinzer/Compare-Net-Objects"
    }
  ]
}
```
