### PR TITLE
Handle endings for opensource.org url

### DIFF
--- a/Sources/ThirdPartyLibraries.Generic.Test/Internal/OpenSourceUrlParserTest.cs
+++ b/Sources/ThirdPartyLibraries.Generic.Test/Internal/OpenSourceUrlParserTest.cs
@@ -14,7 +14,7 @@ public class OpenSourceUrlParserTest
     {
         OpenSourceUrlParser.TryParseLicenseCode(new Uri(url), host, directory, out var actual).ShouldBe(expected != null);
 
-        actual.Equals(expected.AsSpan(), StringComparison.Ordinal).ShouldBeTrue();
+        actual.ToString().ShouldBe(expected ?? string.Empty);
     }
 
     private static IEnumerable<TestCaseData> GetTryParseLicenseCodeCases()
@@ -34,9 +34,14 @@ public class OpenSourceUrlParserTest
             TestName = "opensource.org/license/MIT"
         };
 
-        yield return new TestCaseData("https://opensource.org/licenses/MIT", "opensource.org", "licenses", "MIT")
+        yield return new TestCaseData("http://opensource.org/licenses/mit-license.php", "opensource.org", "licenses", "mit")
         {
-            TestName = "opensource.org/licenses/MIT"
+            TestName = "opensource.org/licenses/MIT-license.php"
+        };
+
+        yield return new TestCaseData("http://opensource.org/licenses/mit-license", "opensource.org", "licenses", "mit")
+        {
+            TestName = "opensource.org/licenses/MIT-license"
         };
 
         yield return new TestCaseData("https://spdx.org/licenses/MIT.html", "spdx.org", "licenses", "MIT.html")

--- a/Sources/ThirdPartyLibraries.Generic/Internal/OpenSourceUrlParser.cs
+++ b/Sources/ThirdPartyLibraries.Generic/Internal/OpenSourceUrlParser.cs
@@ -29,7 +29,25 @@ internal static class OpenSourceUrlParser
             return false;
         }
 
-        code = directory2;
-        return true;
+        code = RemoveEnding(directory2);
+        return code.Length > 0;
+    }
+
+    private static ReadOnlySpan<char> RemoveEnding(ReadOnlySpan<char> code)
+    {
+        const string Ending1 = "-license.php";
+        const string Ending2 = "-license";
+        
+        if (code.EndsWith(Ending1, StringComparison.OrdinalIgnoreCase))
+        {
+            return code.Slice(0, code.Length - Ending1.Length);
+        }
+
+        if (code.EndsWith(Ending2, StringComparison.OrdinalIgnoreCase))
+        {
+            return code.Slice(0, code.Length - Ending2.Length);
+        }
+
+        return code;
     }
 }


### PR DESCRIPTION
The following urls are "identical":
- https://opensource.org/licenses/MIT
- https://opensource.org/licenses/mit-license.php
- https://opensource.org/licenses/mit-license