### PR TITLE
on package delete remove parent folder if is empty

### DIFF
--- a/Sources/ThirdPartyLibraries.Repository.Test/LibraryPathTest.cs
+++ b/Sources/ThirdPartyLibraries.Repository.Test/LibraryPathTest.cs
@@ -1,0 +1,91 @@
+﻿using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Shouldly;
+using ThirdPartyLibraries.Domain;
+
+namespace ThirdPartyLibraries.Repository;
+
+[TestFixture]
+public class LibraryPathTest
+{
+    private TempFolder _location = null!;
+    private DirectoryInfo _root = null!;
+
+    [SetUp]
+    public void BeforeEachTests()
+    {
+        _location = new TempFolder();
+        _root = new DirectoryInfo(_location.Location);
+
+        var path = _root.CreateSubdirectory(Path.Combine("nuget.org", "newtonsoft.json", "12.0.2"));
+        File.WriteAllText(Path.Combine(path.FullName, "dummy.json"), string.Empty);
+
+        path = _root.CreateSubdirectory(Path.Combine("nuget.org", "newtonsoft.json", "12.0.3"));
+        File.WriteAllText(Path.Combine(path.FullName, "dummy.json"), string.Empty);
+
+        path = _root.CreateSubdirectory(Path.Combine("npmjs.com", "@types", "angular", "1.6.51"));
+        File.WriteAllText(Path.Combine(path.FullName, "dummy.json"), string.Empty);
+
+        path = _root.CreateSubdirectory(Path.Combine("npmjs.com", "@types", "angular", "1.7.0"));
+        File.WriteAllText(Path.Combine(path.FullName, "dummy.json"), string.Empty);
+    }
+
+    [TearDown]
+    public void AfterEachTests()
+    {
+        _location.Dispose();
+    }
+
+    [Test]
+    public void AsLibraryId()
+    {
+        var sut = new LibraryPath(_location.Location);
+
+        var actual = sut
+            .GetFiles("dummy.json")
+            .Select(i => sut.AsLibraryId(i.Directory!))
+            .ToArray();
+
+        actual.ShouldBe(
+            [
+                new LibraryId("nuget.org", "newtonsoft.json", "12.0.2"),
+                new LibraryId("nuget.org", "newtonsoft.json", "12.0.3"),
+                new LibraryId("npmjs.com", "@types/angular", "1.7.0"),
+                new LibraryId("npmjs.com", "@types/angular", "1.6.51")
+            ],
+            ignoreOrder: true);
+    }
+
+    [Test]
+    public void RemoveLibraryNewtonsoft()
+    {
+        new LibraryPath(_root)
+            .RemoveLibrary(new DirectoryInfo(Path.Combine(_location.Location, "nuget.org", "newtonsoft.json", "12.0.2")));
+
+        Assert.That(Path.Combine(_location.Location, "nuget.org", "newtonsoft.json", "12.0.2"), Does.Not.Exist);
+        Assert.That(Path.Combine(_location.Location, "nuget.org", "newtonsoft.json", "12.0.3"), Does.Exist);
+
+        new LibraryPath(_root)
+            .RemoveLibrary(new DirectoryInfo(Path.Combine(_location.Location, "nuget.org", "newtonsoft.json", "12.0.3")));
+
+        Assert.That(Path.Combine(_location.Location, "nuget.org"), Does.Exist);
+        Directory.GetFileSystemEntries(Path.Combine(_location.Location, "nuget.org")).ShouldBeEmpty();
+    }
+
+    [Test]
+    public void RemoveLibraryAngular()
+    {
+        new LibraryPath(_root)
+            .RemoveLibrary(new DirectoryInfo(Path.Combine(_location.Location, "npmjs.com", "@types/angular", "1.6.51")));
+
+        Assert.That(Path.Combine(_location.Location, "npmjs.com", "@types", "angular", "1.7.0"), Does.Exist);
+        Assert.That(Path.Combine(_location.Location, "npmjs.com", "@types", "angular", "1.6.51"), Does.Not.Exist);
+
+        new LibraryPath(_root)
+            .RemoveLibrary(new DirectoryInfo(Path.Combine(_location.Location, "npmjs.com", "@types/angular", "1.7.0")));
+
+        Assert.That(Path.Combine(_location.Location, "npmjs.com"), Does.Exist);
+        Directory.GetFileSystemEntries(Path.Combine(_location.Location, "npmjs.com")).ShouldBeEmpty();
+    }
+}

--- a/Sources/ThirdPartyLibraries.Repository/LibraryPath.cs
+++ b/Sources/ThirdPartyLibraries.Repository/LibraryPath.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using ThirdPartyLibraries.Domain;
+
+namespace ThirdPartyLibraries.Repository;
+
+internal readonly struct LibraryPath
+{
+    private readonly DirectoryInfo _root;
+    private readonly int _rootLength;
+
+    public LibraryPath(string root)
+        : this(new DirectoryInfo(root))
+    {
+    }
+
+    public LibraryPath(DirectoryInfo root)
+    {
+        _root = root;
+        _rootLength = GetLength(root);
+    }
+
+    public bool Exists => _root.Exists;
+
+    public FileInfo[] GetFiles(string searchPattern) => _root.GetFiles(searchPattern, SearchOption.AllDirectories);
+
+    public LibraryId AsLibraryId(DirectoryInfo child)
+    {
+        // source/name1/name2/version
+        var version = child.Name;
+
+        var rest = child.Parent!;
+        var restLength = GetLength(rest);
+
+        var name = rest.Name;
+        for (var i = 0; i < (restLength - _rootLength - 2); i++)
+        {
+            rest = rest.Parent!;
+            name = $"{rest.Name}/{name}";
+        }
+
+        var source = rest.Parent!.Name;
+        return new LibraryId(source, name, version);
+    }
+
+    public void RemoveLibrary(DirectoryInfo child)
+    {
+        var childLength = GetLength(child);
+
+        var rest = child;
+        for (var i = 0; i < (childLength - _rootLength - 1); i++)
+        {
+            rest.Delete(true);
+            rest = rest.Parent!;
+            if (rest.GetFileSystemInfos().Length != 0)
+            {
+                break;
+            }
+        }
+    }
+
+    private static int GetLength(DirectoryInfo path)
+    {
+        var result = 0;
+        var temp = path;
+        while (temp != null)
+        {
+            result++;
+            temp = temp.Parent;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
example:

- @typescript-eslint/eslint-plugin/7.1.1
- @typescript-eslint/parser/7.1.1

after removing `parser`:

- @typescript-eslint/eslint-plugin/7.1.1

after removing `eslint-plugin`, the folder `@typescript-eslint` should be deleted as well